### PR TITLE
Change minimum Jenkins from 2.7.3 to 2.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-    <jenkins.version>2.7.3</jenkins.version>
+    <jenkins.version>2.7.1</jenkins.version>
     <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
     <java.level>7</java.level>
     <!-- Jenkins Test Harness version you use to test the plugin. -->


### PR DESCRIPTION
Installing Blue Ocean on 2.7.1 causes compatibility warnings in the plugin manager.

Will need to run a release to fix this one.

PTAL @imeredith 