### PR TITLE
Bug/jenkins 40446

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
       <version>2.6</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>maven-plugin</artifactId>
+      <version>2.14</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-multibranch</artifactId>
       <version>2.8</version>

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -99,11 +99,21 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
     }
 
     static boolean isSupported(Run<?, ?> run) {
-        return SUPPORTED_RUNS.contains(run.getClass());
+        for (Class<?> aClass : SUPPORTED_RUNS) {
+            if (aClass.isInstance(run)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static boolean isSupported(Job<?, ?> job) {
-        return SUPPORTED_JOBS.contains(job.getClass());
+        for (Class<?> aClass : SUPPORTED_JOBS) {
+            if (aClass.isInstance(job)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private String getJobURL(MultiBranchProject<?, ?> project) {

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -16,6 +16,8 @@ import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
+import java.util.Set;
+
 
 /**
  *`@author Ivan Meredith
@@ -23,13 +25,13 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 @Extension
 public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
 
-    private static final ImmutableSet<? extends Class<? extends Run>> SUPPORTED_RUNS = ImmutableSet.of(
+    private static final Set<Class> SUPPORTED_RUNS = ImmutableSet.<Class>of(
             FreeStyleBuild.class,
             WorkflowRun.class,
             AbstractMavenBuild.class
     );
 
-    private static final ImmutableSet<? extends Class<? extends hudson.model.AbstractItem>> SUPPORTED_JOBS = ImmutableSet.of(
+    private static final Set<Class> SUPPORTED_JOBS = ImmutableSet.<Class>of(
             WorkflowJob.class,
             MultiBranchProject.class,
             FreeStyleProject.class,
@@ -100,17 +102,16 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
     }
 
     static boolean isSupported(Run<?, ?> run) {
-        for (Class<?> aClass : SUPPORTED_RUNS) {
-            if (aClass.isInstance(run)) {
-                return true;
-            }
-        }
-        return false;
+        return isInstance(run, SUPPORTED_RUNS);
     }
 
     static boolean isSupported(Job<?, ?> job) {
-        for (Class<?> aClass : SUPPORTED_JOBS) {
-            if (aClass.isInstance(job)) {
+        return isInstance(job, SUPPORTED_JOBS);
+    }
+
+    static boolean isInstance(Object o, Set<Class> classes) {
+        for (Class<?> aClass : classes) {
+            if (aClass.isInstance(o)) {
                 return true;
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -23,8 +23,17 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 @Extension
 public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
 
-    private static final ImmutableSet<? extends Class<? extends Run>> SUPPORTED_RUNS = ImmutableSet.of(FreeStyleBuild.class, WorkflowRun.class, AbstractMavenBuild.class);
-    private static final ImmutableSet<? extends Class<? extends hudson.model.AbstractItem>> SUPPORTED_JOBS = ImmutableSet.of(MultiBranchProject.class, FreeStyleProject.class, AbstractMavenProject.class);
+    private static final ImmutableSet<? extends Class<? extends Run>> SUPPORTED_RUNS = ImmutableSet.of(
+            FreeStyleBuild.class,
+            WorkflowRun.class,
+            AbstractMavenBuild.class
+    );
+
+    private static final ImmutableSet<? extends Class<? extends hudson.model.AbstractItem>> SUPPORTED_JOBS = ImmutableSet.of(
+            MultiBranchProject.class,
+            FreeStyleProject.class,
+            AbstractMavenProject.class
+    );
 
     @Override
     public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -30,6 +30,7 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
     );
 
     private static final ImmutableSet<? extends Class<? extends hudson.model.AbstractItem>> SUPPORTED_JOBS = ImmutableSet.of(
+            WorkflowJob.class,
             MultiBranchProject.class,
             FreeStyleProject.class,
             AbstractMavenProject.class

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import hudson.Extension;
 import hudson.Util;
 import hudson.maven.AbstractMavenBuild;
+import hudson.maven.AbstractMavenProject;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
@@ -23,7 +24,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
 
     private static final ImmutableSet<? extends Class<? extends Run>> SUPPORTED_RUNS = ImmutableSet.of(FreeStyleBuild.class, WorkflowRun.class, AbstractMavenBuild.class);
-    private static final ImmutableSet<? extends Class<? extends hudson.model.AbstractItem>> SUPPORTED_JOBS = ImmutableSet.of(MultiBranchProject.class, FreeStyleProject.class);
+    private static final ImmutableSet<? extends Class<? extends hudson.model.AbstractItem>> SUPPORTED_JOBS = ImmutableSet.of(MultiBranchProject.class, FreeStyleProject.class, AbstractMavenProject.class);
 
     @Override
     public String getDisplayName() {


### PR DESCRIPTION
Need to fall back to the default provider for unsupported job and run types (e.g. matrix)

https://issues.jenkins-ci.org/browse/JENKINS-40446 

Depends on https://github.com/jenkinsci/blueocean-display-url-plugin/pull/2