### PR TITLE
Jenkins 47073 dont use displayname

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(platforms: ['linux'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 node() {
-    docker.image('blueocean_build_env').inside("--net=container:blueo-selenium") {
+    docker.image('blueocean_build_env') {
         withEnv(['GIT_COMMITTER_EMAIL=me@hatescake.com','GIT_COMMITTER_NAME=Hates','GIT_AUTHOR_NAME=Cake','GIT_AUTHOR_EMAIL=hates@cake.com']) {
             stage('Building BlueOcean display url') {
                 sh "mvn clean install"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,13 @@
-buildPlugin(platforms: ['linux'])
+#!groovy
+
+node() {
+    docker.image('blueocean_build_env').inside("--net=container:blueo-selenium") {
+        withEnv(['GIT_COMMITTER_EMAIL=me@hatescake.com','GIT_COMMITTER_NAME=Hates','GIT_AUTHOR_NAME=Cake','GIT_AUTHOR_EMAIL=hates@cake.com']) {
+            stage('Building BlueOcean display url') {
+                sh "mvn clean install"
+                junit 'target/surefire-reports/TEST-*.xml'
+                junit 'target/jest-reports/*.xml'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,21 @@
-#!groovy
-
-node() {
-    docker.image('blueocean_build_env') {
-        withEnv(['GIT_COMMITTER_EMAIL=me@hatescake.com','GIT_COMMITTER_NAME=Hates','GIT_AUTHOR_NAME=Cake','GIT_AUTHOR_EMAIL=hates@cake.com']) {
-            stage('Building BlueOcean display url') {
-                sh "mvn clean install"
-                junit 'target/surefire-reports/TEST-*.xml'
-                junit 'target/jest-reports/*.xml'
+pipeline {
+    agent { docker 'maven' }
+    environment {
+        GIT_COMMITTER_EMAIL = '=me@hatescake.com'
+        GIT_COMMITTER_NAME    = 'Hates'
+        GIT_AUTHOR_NAME = 'Cakes'
+        GIT_AUTHOR_EMAIL = 'hates@cake.com'
+    }
+    stages {
+        stage('build') {
+            steps {
+                sh 'mvn clean install'
             }
+        }
+    }
+    post {
+        always {
+            junit 'target/**/*.xml'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,1 @@
-pipeline {
-  agent { docker 'maven' }
-  stages {
-    stage('build') {
-      steps {
-        sh 'mvn clean install' 
-      }
-    }
-  }
-  post {
-    always {
-      junit 'target/**/*.xml'
-    }
-  }
-}
+buildPlugin()

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -69,12 +69,12 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
             WorkflowJob job = ((WorkflowRun) run).getParent();
             if (job.getParent() instanceof MultiBranchProject) {
                 String jobURL = getJobURL(organization, ((MultiBranchProject) job.getParent()));
-                return String.format("%sdetail/%s/%d/", jobURL, Util.rawEncode(job.getDisplayName()), run.getNumber());
+                return String.format("%sdetail/%s/%d/", jobURL, job.getName(), run.getNumber());
             }
         }
         Job job = run.getParent();
         String jobURL = getJobURL(organization, job);
-        return String.format("%sdetail/%s/%d/", jobURL, Util.rawEncode(job.getDisplayName()), run.getNumber());
+        return String.format("%sdetail/%s/%d/", jobURL, Util.rawEncode(job.getName()), run.getNumber());
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -102,7 +102,13 @@ public class BlueOceanDisplayURLImplTest {
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/abc/", url);
 
     }
-
+    @Test
+    public void testProjectURL_CustomOrganization() throws Exception {
+        FreeStyleProject p = orgFolder.createProject(FreeStyleProject.class, "abc");
+        String url = getPath(displayURL.getJobURL(p));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/abc/", url);
+    }
+    
     @Test
     public void testProjectInFolder() throws Exception {
         MockFolder folder = j.createFolder("test");

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -100,19 +100,14 @@ public class BlueOceanDisplayURLImplTest {
         FreeStyleProject p = j.createFreeStyleProject("abc");
         String url = getPath(displayURL.getJobURL(p));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/abc/", url);
-    }
 
-    @Test
-    public void testProjectURL_CustomOrganization() throws Exception {
-        FreeStyleProject p = orgFolder.createProject(FreeStyleProject.class, "abc");
-        String url = getPath(displayURL.getJobURL(p));
-        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/abc/", url);
     }
 
     @Test
     public void testProjectInFolder() throws Exception {
         MockFolder folder = j.createFolder("test");
         Project p = folder.createProject(FreeStyleProject.class, "abc");
+        p.setDisplayName("custom name");
         String url = getPath(displayURL.getJobURL(p));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/", url);
 
@@ -161,6 +156,26 @@ public class BlueOceanDisplayURLImplTest {
         url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
     }
+
+    @Test
+    public void testMultibranchUrlsWithDisplayNameBranches() throws Exception {
+        repo.checkoutNewBranch("feature/test-1")
+                .writeJenkinsFile(JenkinsFile.createFile().node().stage("stage1").echo("test").endNode())
+                .addFile("Jenkinsfile")
+                .commit("Initial commit to feature/test-1");
+
+        MultiBranchTestBuilder mp = MultiBranchTestBuilder.createProjectInFolder(j, "folder", "test", gitSampleRepoRule);
+
+        WorkflowJob job = mp.scheduleAndFindBranchProject("feature%2Ftest-1");
+        job.setDisplayName("Custom Name");
+        String url = getPath(displayURL.getRunURL(job.getFirstBuild()));
+
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/", url);
+
+        url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
+    }
+
 
     @Test
     public void testMultibranchUrls_CustomOrganization() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -108,7 +108,7 @@ public class BlueOceanDisplayURLImplTest {
         String url = getPath(displayURL.getJobURL(p));
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/abc/", url);
     }
-    
+
     @Test
     public void testProjectInFolder() throws Exception {
         MockFolder folder = j.createFolder("test");


### PR DESCRIPTION
This PR uses the getName function to build the branch past of the run details url

@i386 wdyt about me removing that url encoding? if i didnt, it was double encoding the branch.