### PR TITLE
[JENKINS-53179] Extend env variable to facilitate the access to the BO URLs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -91,6 +91,28 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
         }
     }
 
+    /**
+     * Fully qualified URL for a page that displays tests for a project.
+     */
+    public String getTestsURL(Run<?, ?> run) {
+        if (isSupported(run)) {
+            return getRunURL(run) + "tests";
+        } else {
+            return DisplayURLProvider.getDefault().getRunURL(run);
+        }
+    }
+
+    /**
+     * Fully qualified URL for a page that displays artifacts for a project.
+     */
+    public String getArtifactsURL(Run<?, ?> run) {
+        if (isSupported(run)) {
+            return getRunURL(run) + "artifacts";
+        } else {
+            return DisplayURLProvider.getDefault().getRunURL(run);
+        }
+    }
+
     @Override
     public String getJobURL(Job<?, ?> job) {
         BlueOrganization organization = OrganizationFactory.getInstance().getContainingOrg(job);

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/EnvironmentContributorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/EnvironmentContributorImpl.java
@@ -3,7 +3,6 @@ package org.jenkinsci.plugins.blueoceandisplayurl;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.EnvironmentContributor;
-import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLContext;

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/EnvironmentContributorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/EnvironmentContributorImpl.java
@@ -1,0 +1,29 @@
+package org.jenkinsci.plugins.blueoceandisplayurl;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLContext;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+@Extension
+public class EnvironmentContributorImpl extends EnvironmentContributor {
+    @Override
+    public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        DisplayURLContext ctx = DisplayURLContext.open();
+        try {
+            ctx.run(r);
+            ctx.plugin(null); // environment contributor "comes from" core
+            BlueOceanDisplayURLImpl urlProvider = new BlueOceanDisplayURLImpl();
+            envs.put("RUN_TESTS_DISPLAY_URL", urlProvider.getTestsURL(r));
+            envs.put("RUN_ARTIFACTS_DISPLAY_URL", urlProvider.getArtifactsURL(r));
+        } finally {
+            ctx.close();
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -48,7 +48,7 @@ public class BlueOceanDisplayURLImplTest {
     @Rule
     public GitSampleRepoRule gitSampleRepoRule = new GitSampleRepoRule();
 
-    DisplayURLProvider displayURL;
+    BlueOceanDisplayURLImpl displayURL;
 
     private GitUtil repo;
 
@@ -95,6 +95,11 @@ public class BlueOceanDisplayURLImplTest {
         url = getPath(displayURL.getChangesURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/changes", url);
 
+        url = getPath(displayURL.getTestsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/tests", url);
+
+        url = getPath(displayURL.getArtifactsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/artifacts", url);
     }
 
     @Test
@@ -112,6 +117,11 @@ public class BlueOceanDisplayURLImplTest {
         url = getPath(displayURL.getChangesURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/changes", url);
 
+        url = getPath(displayURL.getTestsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/tests", url);
+
+        url = getPath(displayURL.getArtifactsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/artifacts", url);
     }
 
     @Test
@@ -131,6 +141,12 @@ public class BlueOceanDisplayURLImplTest {
 
         url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
+
+        url = getPath(displayURL.getTestsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/tests", url);
+
+        url = getPath(displayURL.getArtifactsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/artifacts", url);
     }
 
     @Test
@@ -150,6 +166,12 @@ public class BlueOceanDisplayURLImplTest {
 
         url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
+
+        url = getPath(displayURL.getArtifactsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/artifacts", url);
+
+        url = getPath(displayURL.getTestsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/tests", url);
     }
 
 
@@ -170,12 +192,18 @@ public class BlueOceanDisplayURLImplTest {
 
         url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
+
+        url = getPath(displayURL.getTestsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/folder%2Ftest/detail/feature%2Ftest-1/1/tests", url);
+
+        url = getPath(displayURL.getArtifactsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/folder%2Ftest/detail/feature%2Ftest-1/1/artifacts", url);
     }
 
     MockFolder orgFolder;
     @Before
     public void setUp() throws IOException {
-        displayURL = Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(BlueOceanDisplayURLImpl.class));
+        displayURL = new BlueOceanDisplayURLImpl(); //Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(BlueOceanDisplayURLImpl.class));
         orgFolder = j.createFolder("TestOrgFolderName");
         orgFolder.setDisplayName("TestOrgFolderName Display Name");
     }


### PR DESCRIPTION
See [JENKINS-53179](https://issues.jenkins-ci.org/browse/JENKINS-53179)

## Summary
- Enable two env variables with the link to the `artifacts` and `tests` URLs in the Blue ocean.
- `RUN_ARTIFACTS_DISPLAY_URL`
- `RUN_TESTS_DISPLAY_URL`

## Test Cases
![image](https://user-images.githubusercontent.com/2871786/58714019-bc225380-83bb-11e9-8c95-2729509eb37a.png)
