### PR TITLE
[JENKINS-53179] Extend env variable to facilitate the access to the BO URLs

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,5 +1,0 @@
-Enable URLs for a page that displays tests and artifacts for a Run.
-
-## Highlights
-- `` points out to the qualified URL for a page that displays tests for a Run
-- `` points out to the qualified URL for a page that displays artifacts for a Run

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>2.3.3-rc129.d96f21b00c17</version>
+      <version>2.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>2.121.1</jenkins.version>
+    <jenkins.version>2.121.3</jenkins.version>
     <java.level>8</java.level>
     <blueocean.version>1.16.0</blueocean.version>
     <scm-api.version>2.4.1</scm-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>2.3.3-rc125.86e54dc35a15</version>
+      <version>2.3.3-rc129.d96f21b00c17</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>display-url-api</artifactId>
-      <version>2.3.2</version>
+      <version>2.3.3-rc125.86e54dc35a15</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -187,4 +187,5 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
         }
         return group;
     }
+
 }

--- a/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImpl.java
@@ -83,11 +83,29 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
     }
 
     @Override
+    public String getArtifactsURL(Run<?, ?> run) {
+        if (isSupported(run)) {
+            return getRunURL(run) + "artifacts";
+        } else {
+            return DisplayURLProvider.getDefault().getArtifactsURL(run);
+        }
+    }
+
+    @Override
     public String getChangesURL(Run<?, ?> run) {
         if (isSupported(run)) {
             return getRunURL(run) + "changes";
         } else {
             return DisplayURLProvider.getDefault().getChangesURL(run);
+        }
+    }
+
+    @Override
+    public String getTestsURL(Run<?, ?> run) {
+        if (isSupported(run)) {
+            return getRunURL(run) + "tests";
+        } else {
+            return DisplayURLProvider.getDefault().getTestsURL(run);
         }
     }
 
@@ -166,5 +184,4 @@ public class BlueOceanDisplayURLImpl extends DisplayURLProvider {
         }
         return group;
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -251,6 +251,7 @@ public class BlueOceanDisplayURLImplTest {
             return new MultiBranchTestBuilder(j, mp);
         }
 
+
         public WorkflowJob scheduleAndFindBranchProject(String name) throws Exception {
             mp.scheduleBuild2(0).getFuture().get();
             return findBranchProject(name);
@@ -269,6 +270,7 @@ public class BlueOceanDisplayURLImplTest {
             return p;
         }
     }
+
 
     public static class JenkinsFile {
         private String file = "";

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -72,6 +72,7 @@ public class BlueOceanDisplayURLImplTest {
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/abc/", url);
 
     }
+
     @Test
     public void testProjectURL_CustomOrganization() throws Exception {
         FreeStyleProject p = orgFolder.createProject(FreeStyleProject.class, "abc");
@@ -92,9 +93,14 @@ public class BlueOceanDisplayURLImplTest {
         url = getPath(displayURL.getRunURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/", url);
 
+        url = getPath(displayURL.getArtifactsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/artifacts", url);
+
         url = getPath(displayURL.getChangesURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/changes", url);
 
+        url = getPath(displayURL.getTestsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/tests", url);
     }
 
     @Test
@@ -109,9 +115,14 @@ public class BlueOceanDisplayURLImplTest {
         url = getPath(displayURL.getRunURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/", url);
 
+        url = getPath(displayURL.getArtifactsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/artifacts", url);
+
         url = getPath(displayURL.getChangesURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/changes", url);
 
+        url = getPath(displayURL.getTestsURL(p.getLastBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/tests", url);
     }
 
     @Test
@@ -129,8 +140,14 @@ public class BlueOceanDisplayURLImplTest {
 
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/", url);
 
+        url = getPath(displayURL.getArtifactsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/artifacts", url);
+
         url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
+
+        url = getPath(displayURL.getTestsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/tests", url);
     }
 
     @Test
@@ -148,10 +165,15 @@ public class BlueOceanDisplayURLImplTest {
 
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/", url);
 
+        url = getPath(displayURL.getArtifactsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/artifacts", url);
+
         url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
-    }
 
+        url = getPath(displayURL.getTestsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/tests", url);
+    }
 
     @Test
     public void testMultibranchUrls_CustomOrganization() throws Exception {
@@ -168,8 +190,14 @@ public class BlueOceanDisplayURLImplTest {
 
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/folder%2Ftest/detail/feature%2Ftest-1/1/", url);
 
+        url = getPath(displayURL.getArtifactsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/folder%2Ftest/detail/feature%2Ftest-1/1/artifacts", url);
+
         url = getPath(displayURL.getChangesURL(job.getFirstBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/folder%2Ftest/detail/feature%2Ftest-1/1/changes", url);
+
+        url = getPath(displayURL.getTestsURL(job.getFirstBuild()));
+        Assert.assertEquals("/jenkins/blue/organizations/TestOrg/folder%2Ftest/detail/feature%2Ftest-1/1/tests", url);
     }
 
     MockFolder orgFolder;
@@ -223,7 +251,6 @@ public class BlueOceanDisplayURLImplTest {
             return new MultiBranchTestBuilder(j, mp);
         }
 
-
         public WorkflowJob scheduleAndFindBranchProject(String name) throws Exception {
             mp.scheduleBuild2(0).getFuture().get();
             return findBranchProject(name);
@@ -242,7 +269,6 @@ public class BlueOceanDisplayURLImplTest {
             return p;
         }
     }
-
 
     public static class JenkinsFile {
         private String file = "";


### PR DESCRIPTION
[JENKINS-53179](https://issues.jenkins-ci.org/browse/JENKINS-53179)

Enable URLs for a page that displays tests and artifacts for a Run.

Depends on https://github.com/jenkinsci/display-url-api-plugin/pull/25

## Highlights
- `RUN_ARTIFACTS_DISPLAY_URL` points out to the qualified URL for a page that displays artifacts for a Run
- `RUN_TESTS_DISPLAY_URL ` points out to the qualified URL for a page that displays tests for a Run

## UI

```groovy
node {
    sh 'env | grep -i display_ | sort | tee file.txt'
    archive 'file.txt'
}
```

![image](https://user-images.githubusercontent.com/2871786/75484566-f0ee2600-59a0-11ea-9832-2296e2d7ac18.png)

![image](https://user-images.githubusercontent.com/2871786/75484636-11b67b80-59a1-11ea-8a0b-f032401990f1.png)

![image](https://user-images.githubusercontent.com/2871786/75484657-1b3fe380-59a1-11ea-8e1f-d600f1b338ea.png)

@jenkinsci/code-reviewers 