### PR TITLE
Just an example of using the Jenkins BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.49</version>
+    <version>4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>blueocean-display-url</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>
@@ -138,7 +137,6 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This is just an example of building a plugin against the the latest `jenkins.version` and taking advantage of the [jenkins-bom](https://github.com/jenkinsci/jenkins/blob/master/bom/pom.xml). It takes advantage of an [updated plugin-pom](https://github.com/jenkinsci/plugin-pom/pull/229) that provides an optional profile that `import`s the jenkins-bom so that dependencies are synchronised with selected `jenkins.version`.

Using the profile/bom, this plugin can be built against the latest `jenkins.version` without any changes to the pom:
`mvn -Djenkins.version=2.195 -Duse-jenkins-bom -DskipTests clean package`

 cf #47 which doesn't use the bom and required updates to slf4j & commons-codec dependencies.

(the use-jenkins-bom profile is activated on the command line here; when a plugin opts-in to bom usage then this can be streamlined by adding a `.mvn/maven.config` to define the property.)