### PR TITLE
Just an example of _not_ using the Jenkins BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <blueocean.version>1.16.0</blueocean.version>
     <scm-api.version>2.4.1</scm-api.version>
     <git.version>3.10.0</git.version>
+    <slf4jVersion>1.7.26</slf4jVersion>
   </properties>
 
   <name>Display URL for Blue Ocean</name>
@@ -112,7 +113,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.9</version>
+      <version>1.12</version>
     </dependency>
     <dependency>
       <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.49</version>
+    <version>4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>blueocean-display-url</artifactId>


### PR DESCRIPTION
This is just an example of building a plugin against the the latest jenkins.version _without_ taking advantage of the jenkins-bom. Building against 2.95 gives various enforcer errors:
```
mvn -Djenkins.version=2.195 -DskipTests clean package
...
[WARNING] Rule 4: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for commons-codec:commons-codec:1.9 paths to dependency are:
+-org.jenkins-ci.plugins:blueocean-display-url:2.3.1-SNAPSHOT
  +-commons-codec:commons-codec:1.9
and
+-org.jenkins-ci.plugins:blueocean-display-url:2.3.1-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.195
    +-commons-codec:commons-codec:1.12
...
Require upper bound dependencies error for org.slf4j:jcl-over-slf4j:1.7.25 paths to dependency are:
+-org.jenkins-ci.plugins:blueocean-display-url:2.3.1-SNAPSHOT
  +-org.slf4j:jcl-over-slf4j:1.7.25
and
+-org.jenkins-ci.plugins:blueocean-display-url:2.3.1-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.195
    +-org.slf4j:jcl-over-slf4j:1.7.26
...
```

These were fixed by updating the dependencies on slf4j and commons-codec, but cf #46 which uses the bom and required no updates.