### PR TITLE
Fix test setUp for PCT

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.blueoceandisplayurl;
 
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.google.common.base.Predicates;
-import com.google.common.collect.Iterables;
 import hudson.model.FreeStyleProject;
 import hudson.model.ItemGroup;
 import hudson.model.Project;
@@ -175,7 +174,7 @@ public class BlueOceanDisplayURLImplTest {
     MockFolder orgFolder;
     @Before
     public void setUp() throws IOException {
-        displayURL = Iterables.find(DisplayURLProvider.all(), Predicates.instanceOf(BlueOceanDisplayURLImpl.class));
+        displayURL = DisplayURLProvider.all().stream().filter(Predicates.instanceOf(BlueOceanDisplayURLImpl.class)::apply).findFirst().get();
         orgFolder = j.createFolder("TestOrgFolderName");
         orgFolder.setDisplayName("TestOrgFolderName Display Name");
     }


### PR DESCRIPTION
Fix binary compatibility in test `setUp()`. This test is breaking in PCT environment.
See details in https://github.com/jenkinsci/display-url-api-plugin/pull/19/files#r321432088