### PR TITLE
Update tests to handle branch-api v.2.6.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [ platform: "linux", jdk: "8"],
+    [ platform: "windows", jdk: "8"],
+    [ platform: "linux", jdk: "11", jenkins: "2.176.4", javaLevel: "8" ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(configurations: [
     [ platform: "linux", jdk: "8"],
     [ platform: "windows", jdk: "8"],
-    [ platform: "linux", jdk: "11", jenkins: "2.176.4", javaLevel: "8" ]
+    [ platform: "linux", jdk: "11", javaLevel: "8" ]
 ])

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -101,6 +101,7 @@ public class BlueOceanDisplayURLImplTest {
 
         url = getPath(displayURL.getTestsURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/test%2Fabc/detail/abc/1/tests", url);
+        j.waitUntilNoActivity();
     }
 
     @Test
@@ -123,6 +124,7 @@ public class BlueOceanDisplayURLImplTest {
 
         url = getPath(displayURL.getTestsURL(p.getLastBuild()));
         Assert.assertEquals("/jenkins/blue/organizations/TestOrg/test%2Fabc/detail/abc/1/tests", url);
+        j.waitUntilNoActivity();
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/blueoceandisplayurl/BlueOceanDisplayURLImplTest.java
@@ -135,6 +135,7 @@ public class BlueOceanDisplayURLImplTest {
         MultiBranchTestBuilder mp = MultiBranchTestBuilder.createProjectInFolder(j, "folder", "test", gitSampleRepoRule);
 
         WorkflowJob job = mp.scheduleAndFindBranchProject("feature%2Ftest-1");
+        j.waitUntilNoActivity();
 
         String url = getPath(displayURL.getRunURL(job.getFirstBuild()));
 
@@ -161,6 +162,8 @@ public class BlueOceanDisplayURLImplTest {
 
         WorkflowJob job = mp.scheduleAndFindBranchProject("feature%2Ftest-1");
         job.setDisplayName("Custom Name");
+        j.waitUntilNoActivity();
+
         String url = getPath(displayURL.getRunURL(job.getFirstBuild()));
 
         Assert.assertEquals("/jenkins/blue/organizations/jenkins/folder%2Ftest/detail/feature%2Ftest-1/1/", url);
@@ -185,6 +188,7 @@ public class BlueOceanDisplayURLImplTest {
         MultiBranchTestBuilder mp = MultiBranchTestBuilder.createProjectInFolder(j, "folder", "test", gitSampleRepoRule, orgFolder);
 
         WorkflowJob job = mp.scheduleAndFindBranchProject("feature%2Ftest-1");
+        j.waitUntilNoActivity();
 
         String url = getPath(displayURL.getRunURL(job.getFirstBuild()));
 


### PR DESCRIPTION
The latest branch-api honors quiet period. This means some test operations need to wait longer before checking.